### PR TITLE
Added aliases to the netcore app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-
+- Added aliases for .Net Core application
 ### Changed
 
 ### Deprecated

--- a/src/NuGet.Updater.Tool/Program.cs
+++ b/src/NuGet.Updater.Tool/Program.cs
@@ -26,21 +26,21 @@ namespace NuGet.Updater.Tool
 
 			var options = new OptionSet
 			{
-				{ "help", "Displays this help screen", s => isHelp = true },
-				{ "solution=", "The path to the solution to update", s => parameters.SolutionRoot = s },
-				{ "feed=", "The URL of a private NuGet feed to use", s => parameters.SourceFeed = s },
-				{ "pat=", "The PAT used to authenticate to the private NuGet feed", s => parameters.SourceFeedPersonalAccessToken = s },
-				{ "version=", "The target version to use", s => parameters.TargetVersion = s },
+				{ "help|h", "Displays this help screen", s => isHelp = true },
+				{ "solution=|s", "The path to the solution to update", s => parameters.SolutionRoot = s },
+				{ "feed=|f", "The URL of a private NuGet feed to use", s => parameters.SourceFeed = s },
+				{ "pat=|t", "The PAT used to authenticate to the private NuGet feed", s => parameters.SourceFeedPersonalAccessToken = s },
+				{ "version=|v", "The target version to use", s => parameters.TargetVersion = s },
 				{ "strict=", s => parameters.Strict = GetBoolean(s) },
-				{ "excludeTag=", "A tag to exclude from the search", s => parameters.TagToExclude = s },
-				{ "useNuGetorg=", "Whether to pull packages from NuGet.org", s => parameters.IncludeNuGetOrg = GetBoolean(s) },
-				{ "publicPackagesOwner=", "The owner of the public packages to update; must be specified is useNuGetorg is true", s => parameters.PublickPackageOwner = s },
-				{ "allowDowngrade=", "Whether package downgrade is allowed", s => parameters.IsDowngradeAllowed = GetBoolean(s) },
-				{ "keepLatestDev=", "A comma-separated list of packages to keep at latest dev", s => parameters.PackagesToKeepAtLatestDev = GetList(s) },
-				{ "ignore=", "A comma-separated list of packages to ignore", s => parameters.PackagesToIgnore = GetList(s) },
-				{ "update=", "A comma-separated list of packages to update; not specifying this will update all packages found", s => parameters.PackagesToUpdate = GetList(s) },
-				{ "useStableIfMoreRecent=", "Whether to use the latest stable if a more recent version is found", s => parameters.UseStableIfMoreRecent = GetBoolean(s) },
-				{ "outputFile=", "The path to a file where the update summary will be written", s => summaryFile = s },
+				{ "excludeTag=|e", "A tag to exclude from the search", s => parameters.TagToExclude = s },
+				{ "useNuGetorg=|n", "Whether to pull packages from NuGet.org", s => parameters.IncludeNuGetOrg = GetBoolean(s) },
+				{ "publicPackagesOwner=|o", "The owner of the public packages to update; must be specified is useNuGetorg is true", s => parameters.PublickPackageOwner = s },
+				{ "allowDowngrade=|d", "Whether package downgrade is allowed", s => parameters.IsDowngradeAllowed = GetBoolean(s) },
+				{ "keepLatestDev=|k", "A comma-separated list of packages to keep at latest dev", s => parameters.PackagesToKeepAtLatestDev = GetList(s) },
+				{ "ignore=|i", "A comma-separated list of packages to ignore", s => parameters.PackagesToIgnore = GetList(s) },
+				{ "update=|u", "A comma-separated list of packages to update; not specifying this will update all packages found", s => parameters.PackagesToUpdate = GetList(s) },
+				{ "useStableIfMoreRecent=|us", "Whether to use the latest stable if a more recent version is found", s => parameters.UseStableIfMoreRecent = GetBoolean(s) },
+				{ "outputFile=|of", "The path to a file where the update summary will be written", s => summaryFile = s },
 			};
 
 			options.Parse(args);


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

<!-- - Bug fix -->
Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
The .Net Core application requires the full name for its arguments

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
All the arguments now have an alias.


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Contains **NO** breaking changes
- [x] Updated the Changelog
- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

