### PR TITLE
Fixed retrieval of package version in UWP

### DIFF
--- a/src/NuGet.Updater/Extensions/XmlDocumentExtensions.cs
+++ b/src/NuGet.Updater/Extensions/XmlDocumentExtensions.cs
@@ -253,7 +253,7 @@ namespace NuGet.Updater.Extensions
 		private static XmlNode SelectNode(this XmlElement element, string name) => element
 			.ChildNodes
 			.OfType<XmlElement>()
-			.FirstOrDefault(e => e.LocalName == name);
+			.FirstOrDefault(e => e.LocalName.ToString().Equals(name, StringComparison.OrdinalIgnoreCase));
 #endregion
 	}
 }


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
Package version isn't correctly retrieved if it is in a child node in UWP

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Package version is correctly retrieved

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

