### PR TITLE
Put back ignorePackages and updatePackages options for retrocompatibi…

### DIFF
--- a/src/NuGet.Updater.Tool/Program.cs
+++ b/src/NuGet.Updater.Tool/Program.cs
@@ -28,8 +28,8 @@ namespace NuGet.Updater.Tool
 				{ "allowDowngrade|d", "Whether package downgrade is allowed", s => Set(p => p.IsDowngradeAllowed = true)},
 				{ "useNuGetorg|n", "Whether to pull packages from NuGet.org", _ => Set(p => p.IncludeNuGetOrg = true )},
 				{ "packageAuthor=|a=", "The {author} of the packages to update; used for NuGet.org", s => Set(p => p.PackageAuthor = s)},
-				{ "ignore=|i=", "A comma-separated list of {packages} to ignore", s => Set(p => p.PackagesToIgnore = GetList(s)) },
-				{ "update=|u=", "A comma-separated list of {packages} to update; not specifying this will update all packages found", s => Set(p => p.PackagesToUpdate = GetList(s)) },
+				{ "ignorePackages=|ignore=|i=", "A comma-separated list of {packages} to ignore", s => Set(p => p.PackagesToIgnore = GetList(s)) },
+				{ "updatePackages=|update=|u=", "A comma-separated list of {packages} to update; not specifying this will update all packages found", s => Set(p => p.PackagesToUpdate = GetList(s)) },
 				{ "outputFile=|of=", "The {path} to a file where the update summary will be written", s => summaryFile = s },
 			};
 


### PR DESCRIPTION
## Proposed Changes

Bug fix
Build or CI related changes


## What is the current behavior?
The ignorePackages and updatePackages options are not supported anymore


## What is the new behavior?
those options have been added back for retrocompatibility


## Checklist

Please check if your PR fulfills the following requirements:

~~- [ ] Documentation has been added/updated~~
~~- [ ] Automated Unit / Integration tests for the changes have been added/updated~~
- [x] Contains **NO** breaking changes
~~- [ ] Updated the Changelog~~
~~- [ ] Associated with an issue~~

