### PR TITLE
fixed empty option being parsed as list of one empty string

### DIFF
--- a/src/NuGet.Updater.Tool/Program.cs
+++ b/src/NuGet.Updater.Tool/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Mono.Options;
@@ -77,20 +78,6 @@ namespace NuGet.Updater.Tool
 			_isParameterSet = true;
 		}
 
-		private static List<string> GetList(string value)
-		{
-			var list = new List<string>();
-
-			if(value.Contains(","))
-			{
-				list.AddRange(value.Split(","));
-			}
-			else
-			{
-				list.Add(value);
-			}
-
-			return list;
-		}
+		private static string[] GetList(string value) => value.Split(",;".ToArray(), StringSplitOptions.RemoveEmptyEntries);
 	}
 }


### PR DESCRIPTION
GitHub Issue: #n/a

## Proposed Changes
Bug fix

## What is the current behavior?
Passing `-u=` option without specifying anything will be parsed as list of one empty string (`new List<string> { "" }`). This applies to all options that uses `GetList`. This breaks the updater, since it will try to **only** update a package whose packageId is empty string...
ex: `s=qwe -u= -i=asd;zxc`

## What is the new behavior?
Empty option is parsed into empty array.

## Checklist
Please check if your PR fulfills the following requirements:
- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue