### PR TITLE
fixed no package is being updated

### DIFF
--- a/src/NuGet.Updater.Tool/Program.cs
+++ b/src/NuGet.Updater.Tool/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -78,6 +78,6 @@ namespace NuGet.Updater.Tool
 			_isParameterSet = true;
 		}
 
-		private static string[] GetList(string value) => value.Split(",;".ToArray(), StringSplitOptions.RemoveEmptyEntries);
+		private static string[] GetList(string value) => !string.IsNullOrEmpty(value) ? value.Split(",;".ToArray(), StringSplitOptions.RemoveEmptyEntries) : null;
 	}
 }


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- - Bug fix -->

## What is the current behavior?
empty option is parsed into empty array of string.

## What is the new behavior?
empty option is now parsed into `null`.

## Checklist
Please check if your PR fulfills the following requirements:
- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

## Other information
https://github.com/nventive/NuGet.Updater/blob/eeff248d8b15218a6bb2ff8dd7bf48cb46d9309f/src/NuGet.Updater/Extensions/UpdaterParametersExtension.cs#L32
The problem with an empty array of package to update is that none of them gets updated.