### PR TITLE
fixed failure to parse Directory.Build.targets with update

### DIFF
--- a/src/NuGet.Updater/Extensions/XmlDocumentExtensions.cs
+++ b/src/NuGet.Updater/Extensions/XmlDocumentExtensions.cs
@@ -41,7 +41,9 @@ namespace NuGet.Updater.Extensions
 
 			foreach(var packageReference in packageReferences.Concat(dotnetCliReferences))
 			{
-				var packageId = packageReference.GetAttribute("Include");
+				var packageId = new[] { "Include", "Update", "Remove" }
+					.Select(packageReference.GetAttribute)
+					.FirstOrDefault(x => !string.IsNullOrEmpty(x));
 				var packageVersion = packageReference.GetAttribute("Version");
 
 				if(packageVersion.HasValue())


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
Bug fix

## What is the current behavior?
`<PackageReference Update="Microsoft.Extensions.Logging.Console" Version="1.1.1" />` is not parsed correctly. The packageId is empty string...

## What is the new behavior?
Updater should parse `Directory.Build.targets` correctly.

## Checklist
Please check if your PR fulfills the following requirements:
- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue