### PR TITLE
fixed nre when -v options is unspecified or empty

### DIFF
--- a/src/NuGet.Updater.Tool/Program.cs
+++ b/src/NuGet.Updater.Tool/Program.cs
@@ -24,7 +24,7 @@ namespace NuGet.Updater.Tool
 				{ "help|h", "Displays this help screen", s => isHelp = true },
 				{ "solution=|s=", "The {path} to the solution to update", s => Set(p => p.SolutionRoot = s) },
 				{ "feed=|f=", "A private feed to use for the update; the format is {url|accessToken}; can be specified multiple times", s => AddPrivateFeed(s) },
-				{ "version=|versions=|v=", "The target {versions} to use", s => Set(p => p.TargetVersions = GetList(s))},
+				{ "version=|versions=|v=", "The target {versions} to use", s => Set(p => p.TargetVersions = GetList(s) ?? p.TargetVersions)},
 				{ "silent", "Suppress all output from NuGet Updater", _ => isSilent = true },
 				{ "allowDowngrade|d", "Whether package downgrade is allowed", s => Set(p => p.IsDowngradeAllowed = true)},
 				{ "useNuGetorg|n", "Whether to pull packages from NuGet.org", _ => Set(p => p.IncludeNuGetOrg = true )},

--- a/src/NuGet.Updater/Entities/UpdaterParameters.cs
+++ b/src/NuGet.Updater/Entities/UpdaterParameters.cs
@@ -17,7 +17,7 @@ namespace NuGet.Updater.Entities
 		/// <summary>
 		/// Gets or sets the versions to update to (stable, dev, beta, etc.), in order of priority.
 		/// </summary>
-		public IEnumerable<string> TargetVersions { get; set; }
+		public IEnumerable<string> TargetVersions { get; set; } = new[] { "stable" };
 
 		/// <summary>
 		/// Gets or sets a value indicating whether the version should exactly match the target version.


### PR DESCRIPTION
GitHub Issue: #n/a

## Proposed Changes
Bug fix

## What is the current behavior?
NRE is thrown when `-versions` options is not specified or empty.

## What is the new behavior?
`-versions` options defaults to `stable` when it is not specified or empty

## Checklist
Please check if your PR fulfills the following requirements:
- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

## Other information
https://github.com/nventive/NuGet.Updater/blob/caee8e3bc89c5a0026ad3a5b4304a95333480d78/src/NuGet.Updater/Extensions/UpdaterPackageExtensions.cs#L14