### PR TITLE
Updated MSBuild.Extras

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
 	"msbuild-sdks": {
-		"MSBuild.Sdk.Extras": "1.6.68"
+		"MSBuild.Sdk.Extras": "2.0.54"
 	}
 }


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

<!-- - Bug fix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
Version 1.6.68 of MSbuild.Extras seems to cause the build to fail on the latest Windows 2019 with VS2019 images.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Version 2.0.54 properly works.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

