### PR TITLE
Prevented duplicate updates on documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added NuGet.Downloader
+
 #### NuGet.Updater:
 - Added option to do a dry run
 - Added option to have a summary of the operations exectued, allowing to re-execute a specific run
 
 ### Changed
 - Re-organized code to improve reusability
+
+### Fixed
+- Fixed a double call of the method used to update the documents; this was causing the update to work but a wrong output.
 
 ## Version 1.0
 

--- a/src/NuGet.Updater/NuGetUpdater.cs
+++ b/src/NuGet.Updater/NuGetUpdater.cs
@@ -64,7 +64,9 @@ namespace NuGet.Updater
 
 			foreach(var package in packages)
 			{
-				if(package.Version == null)
+				var version = package.Version;
+
+				if(version == null)
 				{
 					var targetVersionText = string.Join(" or ", _parameters.TargetVersions);
 
@@ -79,7 +81,7 @@ namespace NuGet.Updater
 				{
 					var operation = package.ToUpdateOperation(_parameters.IsDowngradeAllowed);
 
-					if(package.Version.IsOverride)
+					if(version.IsOverride)
 					{
 						_log.Write($"Version forced to [{operation.UpdatedVersion}] for [{operation.PackageId}]");
 					}
@@ -90,8 +92,6 @@ namespace NuGet.Updater
 
 					_log.Write(await UpdateFiles(ct, operation, package.Reference.Files, documents));
 				}
-
-				_log.Write("");
 			}
 
 			_log.WriteSummary(_parameters);
@@ -162,15 +162,15 @@ namespace NuGet.Updater
 
 					IEnumerable<UpdateOperation> updates = Array.Empty<UpdateOperation>();
 
-					operation = operation.WithFilePath(path);
+					var currentOperation = operation.WithFilePath(path);
 
 					if(fileType.HasFlag(FileType.Nuspec))
 					{
-						updates = document.UpdateDependencies(operation);
+						updates = document.UpdateDependencies(currentOperation);
 					}
 					else if(fileType.HasAnyFlag(FileType.DirectoryProps, FileType.DirectoryTargets, FileType.Csproj))
 					{
-						updates = document.UpdatePackageReferences(operation);
+						updates = document.UpdatePackageReferences(currentOperation);
 					}
 
 					if(!_parameters.IsDryRun && updates.Any(u => u.ShouldProceed))


### PR DESCRIPTION
This was causing the output to incorrectly report the package as already being at the latest version.

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
When updating packages, the output incorrectly states that the packages are already at latest version. This is caused by a double update on the XmlDocument, the first working properly and the second one stating that there's nothing to do. 

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
The methods updating the XmlDocument have been tweaked. They no longer make use of yield return (yield return in a foreach loop), which was the probable cause for the double update.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

