### PR TITLE
Adjust directory separator

### DIFF
--- a/src/NuGet.Shared/Helpers/SolutionHelper.cs
+++ b/src/NuGet.Shared/Helpers/SolutionHelper.cs
@@ -86,7 +86,7 @@ namespace NuGet.Shared.Helpers
 				files = Regex
 					.Matches(solutionContent, "[^\\s\"]*\\.csproj")
 					.Cast<Match>()
-					.Select(m => Path.Combine(solutionFolder, m.Value))
+					.Select(m => Path.Combine(solutionFolder, m.Value.Replace('\\', Path.DirectorySeparatorChar)))
 					.ToArray();
 			}
 
@@ -138,7 +138,7 @@ namespace NuGet.Shared.Helpers
 			var files = await FileHelper.GetFiles(ct, solutionFolder, extensionFilter: ".nuspec");
 
 			//Nuspec files are generated in obj when using the new csproj format
-			files = files.Where(f => !f.Contains("\\obj\\", StringComparison.OrdinalIgnoreCase)).ToArray();
+			files = files.Where(f => !f.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)).ToArray();
 
 			log.LogInformation($"Found {files.Length} nuspec files");
 


### PR DESCRIPTION
## Proposed Changes
- Bug fix

## What is the current behavior?
Solution parsing uses explicit `\` where paths should be adjusted to use the current platform's separator.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

