### PR TITLE
fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ NuGet packages manipulations made easy.
 
 ## NuGet.Updater
 
-Documentation about the NuGet.Updater can be found [here](src/NuGet.Updater.Tool/README.md)
+Documentation about the NuGet.Updater can be found [here](src/NuGet.Updater.Tool/Readme.md)
 
 ## NuGet.Downloader
 


### PR DESCRIPTION
GitHub Issue: #n/a

## Proposed Changes
- Documentation content changes


## What is the current behavior?
A link on the main page is broken.

## What is the new behavior?
fixed the broken link for NuGet.Updater.Tool README

## Checklist
Please check if your PR fulfills the following requirements:
- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue