### PR TITLE
Fixed file existence check in UWP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+### Changed
+### Fixed
+- Fixed issue where the UWP implementation was not properly checking for files' existence.
+### Removed
+
+## Version 2.1
+
+### Added
 - Added NuGet.Downloader
 - Added proper parsing of the versions read in the files
 

--- a/src/NuGet.Shared/Extensions/DictionaryExtensions.cs
+++ b/src/NuGet.Shared/Extensions/DictionaryExtensions.cs
@@ -13,7 +13,7 @@ namespace NuGet.Shared.Extensions
 			.Where(g => keys.Contains(g.Key))
 			.ToDictionary(g => g.Key, g => g.Value);
 
-#if !UAP
+#if !WINDOWS_UWP
 		public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
 		{
 			if(dictionary.ContainsKey(key))

--- a/src/NuGet.Shared/Extensions/PackageSourceExtensions.cs
+++ b/src/NuGet.Shared/Extensions/PackageSourceExtensions.cs
@@ -39,7 +39,7 @@ namespace NuGet.Shared.Extensions
 
 			return new PackageSource(url)
 			{
-#if UAP
+#if WINDOWS_UWP
 				Credentials = PackageSourceCredential.FromUserInput(sourceName, "user", accessToken, false),
 #else
 				Credentials = PackageSourceCredential.FromUserInput(sourceName, "user", accessToken, false, null),

--- a/src/NuGet.Shared/Extensions/XmlDocumentExtensions.cs
+++ b/src/NuGet.Shared/Extensions/XmlDocumentExtensions.cs
@@ -7,7 +7,7 @@ using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Uno.Extensions;
 
-#if UAP
+#if WINDOWS_UWP
 using System.Text.RegularExpressions;
 using Windows.Data.Xml.Dom;
 using Windows.Storage;
@@ -94,7 +94,7 @@ namespace NuGet.Shared.Extensions
 		/// <returns></returns>
 		public static async Task<XmlDocument> LoadDocument(this string path, CancellationToken ct)
 		{
-#if UAP
+#if WINDOWS_UWP
 			var file = await StorageFile
 				.GetFileFromPathAsync(path)
 				.AsTask(ct);
@@ -123,7 +123,7 @@ namespace NuGet.Shared.Extensions
 		/// <returns></returns>
 		public static async Task Save(this XmlDocument document, CancellationToken ct, string path)
 		{
-#if UAP
+#if WINDOWS_UWP
 			var xml = document.GetXml();
 
 			xml = Regex.Replace(xml, @"(<\? ?xml)(?<declaration>.+)( ?\?>)", x => !x.Groups["declaration"].Value.Contains("encoding", StringComparison.OrdinalIgnoreCase)

--- a/src/NuGet.Shared/Helpers/FileHelper.Net.cs
+++ b/src/NuGet.Shared/Helpers/FileHelper.Net.cs
@@ -1,4 +1,4 @@
-﻿#if !UAP
+﻿#if !WINDOWS_UWP
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -46,6 +46,8 @@ namespace NuGet.Shared.Helpers
 		{
 			return (File.GetAttributes(path) & FileAttributes.Directory) == FileAttributes.Directory;
 		}
+
+		public static async Task<bool> Exists(string path) => File.Exists(path);
 	}
 }
 #endif

--- a/src/NuGet.Shared/Helpers/FileHelper.UAP.cs
+++ b/src/NuGet.Shared/Helpers/FileHelper.UAP.cs
@@ -1,6 +1,5 @@
-﻿#if UAP
+﻿#if WINDOWS_UWP
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -69,6 +68,19 @@ namespace NuGet.Shared.Helpers
 				return true;
 			}
 			catch(ArgumentException)
+			{
+				return false;
+			}
+		}
+
+		public static async Task<bool> Exists(string path)
+		{
+			try
+			{
+				var file = await StorageFile.GetFileFromPathAsync(path);
+				return true;
+			}
+			catch(Exception)
 			{
 				return false;
 			}

--- a/src/NuGet.Shared/Helpers/SolutionHelper.cs
+++ b/src/NuGet.Shared/Helpers/SolutionHelper.cs
@@ -118,7 +118,7 @@ namespace NuGet.Shared.Helpers
 				file = Path.Combine(solutionFolder, target.GetDescription());
 			}
 
-			if(file.HasValue() && File.Exists(file))
+			if(file.HasValue() && await FileHelper.Exists(file))
 			{
 				log.LogInformation($"Found {target.GetDescription()}");
 				return new[] { file };

--- a/src/NuGet.Updater/Extensions/PackageReferenceExtensions.cs
+++ b/src/NuGet.Updater/Extensions/PackageReferenceExtensions.cs
@@ -8,7 +8,7 @@ using NuGet.Shared.Extensions;
 using NuGet.Updater.Entities;
 using Uno.Extensions;
 
-#if UAP
+#if WINDOWS_UWP
 using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
 #else
 using XmlDocument = System.Xml.XmlDocument;

--- a/src/NuGet.Updater/Extensions/XmlDocumentExtensions.cs
+++ b/src/NuGet.Updater/Extensions/XmlDocumentExtensions.cs
@@ -5,7 +5,7 @@ using NuGet.Shared.Extensions;
 using NuGet.Updater.Log;
 using Uno.Extensions;
 
-#if UAP
+#if WINDOWS_UWP
 using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
 using XmlElement = Windows.Data.Xml.Dom.XmlElement;
 #else

--- a/src/NuGet.Updater/NuGet.Updater.csproj
+++ b/src/NuGet.Updater/NuGet.Updater.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard20;net472;uap10.0.17134</TargetFrameworks>
+		<TargetFrameworks>netstandard20;net472;uap10.0.17763</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<LangVersion>7.2</LangVersion>
 	</PropertyGroup>
@@ -14,10 +14,6 @@
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/nventive/NuGet.Updater</PackageProjectUrl>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)'=='uap10.0.17134'">
-		<DefineConstants>UAP</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -35,7 +31,7 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.17134'">
+	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.17763'">
 		<PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
 		<!-- Version of NuGet.Protocol compatible with UAP (doesn't try to read/write NuGet.config) -->
@@ -55,7 +51,7 @@
 		<ItemGroup>
 			<Content Include="../Packages/Nuget.Protocol/uap10.0/*.dll">
 				<Pack>true</Pack>
-				<PackagePath>lib/uap10.0.17134</PackagePath>
+				<PackagePath>lib/uap10.0.17763</PackagePath>
 			</Content>
 		</ItemGroup>
 	</Target>

--- a/src/NuGet.Updater/NuGetUpdater.cs
+++ b/src/NuGet.Updater/NuGetUpdater.cs
@@ -12,7 +12,7 @@ using NuGet.Updater.Extensions;
 using NuGet.Updater.Log;
 using Uno.Extensions;
 
-#if UAP
+#if WINDOWS_UWP
 using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
 #else
 using XmlDocument = System.Xml.XmlDocument;


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
File.Exists is used to check for a file's existence in UWP, which always returns false.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
UWP now uses the proper API to check for a file's existence.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

