### PR TITLE
Added alternate separator for the package sources

### DIFF
--- a/src/NvGet/Extensions/PackageSourceExtensions.cs
+++ b/src/NvGet/Extensions/PackageSourceExtensions.cs
@@ -8,6 +8,7 @@ namespace NuGet.Shared.Extensions
 	public static class PackageSourceExtensions
 	{
 		private const char PackageFeedInputSeparator = '|';
+		private const char AlternatePackageFeedInputSeparator = ',';
 
 		/// <summary>
 		/// Transforms a input string into a package feed
@@ -19,6 +20,12 @@ namespace NuGet.Shared.Extensions
 		public static PackageSource ToPackageSource(this string input)
 		{
 			var parts = input.Split(PackageFeedInputSeparator);
+			
+			//If nothing split, try with the alternate separator 
+			if(parts.Length == 1)
+			{
+				parts = input.Split(AlternatePackageFeedInputSeparator);
+			}
 
 			var url = parts.ElementAtOrDefault(0);
 			var accessToken = parts.ElementAtOrDefault(1);


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

<!-- - Bug fix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
Package feed authentication is passed with |, which makes it difficult to use in a command line

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Added a new character ',' to pass the authentication

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

