### PR TITLE
Ensured source check is not done initially

### DIFF
--- a/src/NvGet/NvGet.csproj
+++ b/src/NvGet/NvGet.csproj
@@ -3,7 +3,7 @@
 		<TargetFrameworks>netstandard20;net472</TargetFrameworks>
 		<NoWarn>$(NoWarn);CA1068;NU1701</NoWarn>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<LangVersion>7.2</LangVersion>
+		<LangVersion>9.0</LangVersion>
 	</PropertyGroup>
 
 	<!-- NuGet metadata -->


### PR DESCRIPTION
This will ensure the app starts faster and potential 401 errors will bubble up instead of being misinsterpreted as parsing errors

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

<!-- - Bug fix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
NuGet resources are being fetched directly when the package feed is created, causing the application to stay unresponsive while everything is setup. Also, potential 401 errors are being intercepted as parsing errors.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
NuGet resources are fetched when necessary, making the the application feel more responsive, and 401 errors to bubble up properly

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

