### PR TITLE
fix: Handle CPM files

### DIFF
--- a/src/NvGet/Helpers/SolutionHelper.cs
+++ b/src/NvGet/Helpers/SolutionHelper.cs
@@ -171,7 +171,7 @@ namespace NvGet.Helpers
 			var document = await file.LoadDocument(ct);
 			var references = Array.Empty<PackageIdentity>();
 
-			if(target.HasAnyFlag(FileType.Csproj, FileType.DirectoryProps, FileType.DirectoryTargets))
+			if(target.HasAnyFlag(FileType.Csproj, FileType.DirectoryProps, FileType.DirectoryTargets, FileType.CentralPackageManagement))
 			{
 				references = document.GetPackageReferences();
 			}

--- a/src/NvGet/Tools/Updater/Extensions/XmlDocumentExtensions.cs
+++ b/src/NvGet/Tools/Updater/Extensions/XmlDocumentExtensions.cs
@@ -33,8 +33,9 @@ namespace NvGet.Tools.Updater.Extensions
 
 			var packageReferences = document.SelectElements("PackageReference", $"[@Include='{packageId}' or @Update='{packageId}']");
 			var dotnetCliReferences = document.SelectElements("DotNetCliToolReference", $"[@Include='{packageId}' or @Update='{packageId}']");
+			var packageVersions = document.SelectElements("PackageVersion", $"[@Include='{packageId}' or @Update='{packageId}']");
 
-			foreach(var packageReference in packageReferences.Concat(dotnetCliReferences))
+			foreach(var packageReference in packageReferences.Concat(dotnetCliReferences).Concat(packageVersions))
 			{
 				var packageVersion = packageReference.GetAttributeOrChild("Version");
 

--- a/src/NvGet/Tools/Updater/NuGetUpdater.cs
+++ b/src/NvGet/Tools/Updater/NuGetUpdater.cs
@@ -170,7 +170,7 @@ namespace NvGet.Tools.Updater
 					{
 						updates = document.UpdateDependencies(currentOperation);
 					}
-					else if(fileType.HasAnyFlag(FileType.DirectoryProps, FileType.DirectoryTargets, FileType.Csproj))
+					else if(fileType.HasAnyFlag(FileType.DirectoryProps, FileType.DirectoryTargets, FileType.Csproj, FileType.CentralPackageManagement))
 					{
 						updates = document.UpdatePackageReferences(currentOperation);
 					}


### PR DESCRIPTION
GitHub Issue: #63 

## Proposed Changes
- Bug fix

## What is the current behavior?
Directory.Packages.props is included in files to read from but then excluded when getting packages to update. It's also excluded from updating package references

## What is the new behavior?
Directory.Packages.props is updated as necessary

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

