### PR TITLE
chore: Renaming projectProperties to updateProperties

### DIFF
--- a/src/NvGet.Tools.Shared/Arguments/ConsoleArgsContext.cs
+++ b/src/NvGet.Tools.Shared/Arguments/ConsoleArgsContext.cs
@@ -53,7 +53,7 @@ namespace NvGet.Tools.Arguments
 				{ "dryrun", "Runs the updater but doesn't write the updates to files.", TrySet(_ => context.Parameters.IsDryRun = true) },
 				{ "result|r=", "The path to the file where the update result should be saved.", TrySet(x => context.ResultFile = x) },
 				{ "versionOverrides=", "The path to a JSON file to force specifc versions to be used; format should be the same as the result file", TryParseAndSet(LoadOverrides, x => context.Parameters.VersionOverrides.AddRange(x)) },
-				{ "projectProperties=", "The path to a JSON file that lists pairs of csproj property names and corresponding package Id, so that updater can update project properties as necessary", TryParseAndSet(LoadProjectProperties, x => context.Parameters.ProjectProperties.AddRange(x)) },
+				{ "updateProperties=", "The path to a JSON file that lists pairs of csproj property names and corresponding package Id, so that updater can update project properties as necessary", TryParseAndSet(LoadUpdateProperties, x => context.Parameters.UpdateProperties.AddRange(x)) },
 			};
 
 			Action<string> TrySet(Action<string> set)
@@ -144,7 +144,7 @@ namespace NvGet.Tools.Arguments
 			}
 		}
 
-		internal static IEnumerable<(string PropertyName, string PackageId)> LoadProjectProperties(string inputPathOrUrl)
+		internal static IEnumerable<(string PropertyName, string PackageId)> LoadUpdateProperties(string inputPathOrUrl)
 		{
 			var results =
 				LoadFromStreamAsync()

--- a/src/NvGet.Tools.Updater/Readme.md
+++ b/src/NvGet.Tools.Updater/Readme.md
@@ -82,7 +82,7 @@ versions.json example:
 ```
 
 ```
-nugetupdater -s=MySolution.sln -n -v=dev -v=stable --allowDowngrade --projectProperties=properties.json
+nugetupdater -s=MySolution.sln -n -v=dev -v=stable --allowDowngrade --updateProperties=properties.json
 ```
 properties.json example:
 ```

--- a/src/NvGet/Extensions/XmlDocumentExtensions.cs
+++ b/src/NvGet/Extensions/XmlDocumentExtensions.cs
@@ -26,15 +26,15 @@ namespace NvGet.Extensions
 	public static class XmlDocumentExtensions
 	{
 		/// <summary>
-		/// Retrieves the ProjectProperties that need updating from the given XmlDocument.
+		/// Retrieves the UpdateProperties that need updating from the given XmlDocument.
 		/// </summary>
 		/// <param name="document"></param>
 		/// <returns>A Dictionary where the key is the id of a package and the value its version.</returns>
-		public static PackageIdentity[] GetProjectProperties(this XmlDocument document, ICollection<(string PropertyName, string PackageId)> projectProperties)
+		public static PackageIdentity[] GetUpdateProperties(this XmlDocument document, ICollection<(string PropertyName, string PackageId)> updateProperties)
 		{
 			var references = new List<PackageIdentity>();
 
-			foreach(var prop in projectProperties)
+			foreach(var prop in updateProperties)
 			{
 				var docProp = document.SelectElements(prop.PropertyName).FirstOrDefault();
 				if(docProp is null)

--- a/src/NvGet/Helpers/SolutionHelper.cs
+++ b/src/NvGet/Helpers/SolutionHelper.cs
@@ -25,10 +25,10 @@ namespace NvGet.Helpers
 			string solutionPath,
 			FileType fileType,
 			ILogger log,
-			ICollection<(string PropertyName, string PackageId)>? projectProperties = default
+			ICollection<(string PropertyName, string PackageId)>? updateProperties = default
 		)
 		{
-			projectProperties ??= Array.Empty<(string PropertyName, string PackageId)>();
+			updateProperties ??= Array.Empty<(string PropertyName, string PackageId)>();
 
 			log.LogInformation($"Retrieving references from files in {solutionPath}");
 
@@ -38,7 +38,7 @@ namespace NvGet.Helpers
 			{
 				foreach(var f in await GetProjectFiles(ct, solutionPath, log))
 				{
-					packages.AddRange(await GetFileReferences(ct, f, FileType.Csproj, projectProperties));
+					packages.AddRange(await GetFileReferences(ct, f, FileType.Csproj, updateProperties));
 				}
 			}
 
@@ -48,7 +48,7 @@ namespace NvGet.Helpers
 
 				foreach(var file in await GetDirectoryFiles(ct, solutionPath, currentTarget, log))
 				{
-					packages.AddRange(await GetFileReferences(ct, file, currentTarget, projectProperties));
+					packages.AddRange(await GetFileReferences(ct, file, currentTarget, updateProperties));
 				}
 			}
 
@@ -58,7 +58,7 @@ namespace NvGet.Helpers
 
 				foreach(var file in await GetDirectoryFiles(ct, solutionPath, currentTarget, log))
 				{
-					packages.AddRange(await GetFileReferences(ct, file, currentTarget, projectProperties));
+					packages.AddRange(await GetFileReferences(ct, file, currentTarget, updateProperties));
 				}
 			}
 
@@ -68,7 +68,7 @@ namespace NvGet.Helpers
 
 				foreach(var file in await GetDirectoryFiles(ct, solutionPath, currentTarget, log))
 				{
-					packages.AddRange(await GetFileReferences(ct, file, currentTarget, projectProperties));
+					packages.AddRange(await GetFileReferences(ct, file, currentTarget, updateProperties));
 				}
 			}
 
@@ -76,7 +76,7 @@ namespace NvGet.Helpers
 			{
 				foreach(var f in await GetNuspecFiles(ct, solutionPath, log))
 				{
-					packages.AddRange(await GetFileReferences(ct, f, FileType.Nuspec, projectProperties));
+					packages.AddRange(await GetFileReferences(ct, f, FileType.Nuspec, updateProperties));
 				}
 			}
 
@@ -164,7 +164,7 @@ namespace NvGet.Helpers
 			return files;
 		}
 
-		private static async Task<PackageReference[]> GetFileReferences(CancellationToken ct, string file, FileType target, ICollection<(string PropertyName, string PackageId)> projectProperties)
+		private static async Task<PackageReference[]> GetFileReferences(CancellationToken ct, string file, FileType target, ICollection<(string PropertyName, string PackageId)> updateProperties)
 		{
 			if(file.IsNullOrEmpty())
 			{
@@ -176,7 +176,7 @@ namespace NvGet.Helpers
 
 			if(target.HasAnyFlag(FileType.Csproj, FileType.DirectoryProps, FileType.DirectoryTargets, FileType.CentralPackageManagement))
 			{
-				references = document.GetPackageReferences().Concat(document.GetProjectProperties(projectProperties)).ToArray();
+				references = document.GetPackageReferences().Concat(document.GetUpdateProperties(updateProperties)).ToArray();
 			}
 			else if(target.HasFlag(FileType.Nuspec))
 			{

--- a/src/NvGet/Tools/Updater/Entities/UpdaterParameters.cs
+++ b/src/NvGet/Tools/Updater/Entities/UpdaterParameters.cs
@@ -63,7 +63,7 @@ namespace NvGet.Tools.Updater.Entities
 		/// <summary>
 		/// Gets the csproj properties that should be updated for corresponding package.
 		/// </summary>
-		public ICollection<(string PropertyName, string PackageId)> ProjectProperties { get; } = new List<(string PropertyNaem, string PackageId)>();
+		public ICollection<(string PropertyName, string PackageId)> UpdateProperties { get; } = new List<(string PropertyNaem, string PackageId)>();
 
 		/// <summary>
 		/// Gets or sets a value indicating whether to actually write the updates to the files.

--- a/src/NvGet/Tools/Updater/Extensions/XmlDocumentExtensions.cs
+++ b/src/NvGet/Tools/Updater/Extensions/XmlDocumentExtensions.cs
@@ -22,16 +22,16 @@ namespace NvGet.Tools.Updater.Extensions
 		/// <param name="document"></param>
 		/// <param name="operation"></param>
 		/// <returns></returns>
-		public static IEnumerable<UpdateOperation> UpdateProjectProperties(
+		public static IEnumerable<UpdateOperation> UpdateUpdateProperties(
 			this XmlDocument document,
 			UpdateOperation operation,
-			ICollection<(string PropertyName, string PackageId)> projectProperties)
+			ICollection<(string PropertyName, string PackageId)> updateProperties)
 		{
 			var operations = new List<UpdateOperation>();
 
 			var packageId = operation.PackageId;
 
-			foreach(var prop in projectProperties.Where(x=> x.PackageId == packageId))
+			foreach(var prop in updateProperties.Where(x=> x.PackageId == packageId))
 			{
 				var docProp = document.SelectElements(prop.PropertyName).FirstOrDefault();
 				if(docProp is null)

--- a/src/NvGet/Tools/Updater/NuGetUpdater.cs
+++ b/src/NvGet/Tools/Updater/NuGetUpdater.cs
@@ -108,7 +108,7 @@ namespace NvGet.Tools.Updater
 		internal async Task<UpdaterPackage[]> GetPackages(CancellationToken ct)
 		{
 			var packages = new List<UpdaterPackage>();
-			var references = await SolutionHelper.GetPackageReferences(ct, _parameters.SolutionRoot, _parameters.UpdateTarget, _log, _parameters.ProjectProperties);
+			var references = await SolutionHelper.GetPackageReferences(ct, _parameters.SolutionRoot, _parameters.UpdateTarget, _log, _parameters.UpdateProperties);
 
 			_log.Write($"Found {references.Length} references");
 
@@ -173,7 +173,7 @@ namespace NvGet.Tools.Updater
 					else if(fileType.HasAnyFlag(FileType.DirectoryProps, FileType.DirectoryTargets, FileType.Csproj, FileType.CentralPackageManagement))
 					{
 						updates = document.UpdatePackageReferences(currentOperation);
-						var propertyUpdates = document.UpdateProjectProperties(currentOperation, _parameters.ProjectProperties);
+						var propertyUpdates = document.UpdateUpdateProperties(currentOperation, _parameters.UpdateProperties);
 						updates = updates.Concat(propertyUpdates);
 					}
 


### PR DESCRIPTION
## Proposed Changes
- Chore

## What is the current behavior?
Parameter for specifying project properties to set with updated version is projectProperties

## What is the new behavior?
Parameter for specifying project properties to set with updated version is updateProperties


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

