### PR TITLE
Add support for global.json and `*Version` properties updates

### DIFF
--- a/src/NvGet.Tools.Updater/Readme.md
+++ b/src/NvGet.Tools.Updater/Readme.md
@@ -94,3 +94,15 @@ properties.json example:
 ]
 ```
 In this case the `UnoVersion` property will be updated to the latest version of `Uno.UI` found in the solution.
+
+## Supported types of updates
+
+The nuget updater supports updating:
+- `.csproj`, `Directory.Build.props`, `Directory.Build.targets` and `Directory.Packages.props`
+    For this type of files, the tool will update:
+    - `PackageReference` and `PackageVersion` items
+    - MSBuild properties using named this way `UnoWinUIVersion` or `UnoExtensionsNavigationVersion`
+- `.nuspec`
+  For this type of files, the tool will update `reference` entries.
+- `global.json`
+  For this type of files, the tool will update `msbuild-sdk` entries

--- a/src/NvGet/Contracts/FileType.cs
+++ b/src/NvGet/Contracts/FileType.cs
@@ -39,8 +39,13 @@ namespace NvGet.Contracts
 		CentralPackageManagement = 32,
 
 		/// <summary>
+		/// global.json files.
+		/// </summary>
+		GlobalJson = 64,
+
+		/// <summary>
 		/// All the supported file types.
 		/// </summary>
-		All = Nuspec | Csproj | DirectoryProps | DirectoryTargets | CentralPackageManagement,
+		All = Nuspec | Csproj | DirectoryProps | DirectoryTargets | CentralPackageManagement | GlobalJson,
 	}
 }

--- a/src/NvGet/Extensions/DocumentReference.cs
+++ b/src/NvGet/Extensions/DocumentReference.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NvGet.Entities;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Uno.Extensions;
+
+#if WINDOWS_UWP
+using System.Text.RegularExpressions;
+using Windows.Data.Xml.Dom;
+using Windows.Storage;
+using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
+using XmlElement = Windows.Data.Xml.Dom.XmlElement;
+using XmlNode = Windows.Data.Xml.Dom.IXmlNode;
+#else
+using XmlDocument = System.Xml.XmlDocument;
+using XmlElement = System.Xml.XmlElement;
+using XmlNode = System.Xml.XmlNode;
+#endif
+
+namespace NvGet.Extensions
+{
+	public abstract class DocumentReference
+	{
+		public abstract Task Save(CancellationToken ct, string path);
+	}
+}

--- a/src/NvGet/Extensions/FileTypeExtensions.cs
+++ b/src/NvGet/Extensions/FileTypeExtensions.cs
@@ -8,21 +8,16 @@ namespace NvGet.Extensions
 	{
 		public static string GetDescription(this FileType target)
 		{
-			switch(target)
+			return target switch
 			{
-				case FileType.Nuspec:
-					return ".nuspec";
-				case FileType.Csproj:
-					return ".csproj";
-				case FileType.DirectoryProps:
-					return "Directory.Build.targets";
-				case FileType.DirectoryTargets:
-					return "Directory.Build.props";
-				case FileType.CentralPackageManagement:
-					return "Directory.Packages.props";
-				default:
-					return default;
-			}
+				FileType.Nuspec => ".nuspec",
+				FileType.Csproj => ".csproj",
+				FileType.DirectoryProps => "Directory.Build.targets",
+				FileType.DirectoryTargets => "Directory.Build.props",
+				FileType.CentralPackageManagement => "Directory.Packages.props",
+				FileType.GlobalJson => "global.json",
+				_ => default,
+			};
 		}
 
 		public static bool HasAnyFlag(this FileType target, params FileType[] others)

--- a/src/NvGet/Extensions/JsonDocumentReference.cs
+++ b/src/NvGet/Extensions/JsonDocumentReference.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NvGet.Entities;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Uno.Extensions;
+
+#if WINDOWS_UWP
+using System.Text.RegularExpressions;
+using Windows.Data.Xml.Dom;
+using Windows.Storage;
+using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
+using XmlElement = Windows.Data.Xml.Dom.XmlElement;
+using XmlNode = Windows.Data.Xml.Dom.IXmlNode;
+#else
+using XmlDocument = System.Xml.XmlDocument;
+using XmlElement = System.Xml.XmlElement;
+using XmlNode = System.Xml.XmlNode;
+#endif
+
+namespace NvGet.Extensions
+{
+	public class JsonDocumentReference : DocumentReference
+	{
+		public JsonDocumentReference(string contents)
+		{
+			Contents = contents;
+		}
+
+		public string Contents { get; set; }
+
+		public override async Task Save(CancellationToken ct, string path)
+		{
+			System.IO.File.WriteAllText(path, Contents);
+		}
+	}
+}

--- a/src/NvGet/Extensions/XmlDocumentExtensions.cs
+++ b/src/NvGet/Extensions/XmlDocumentExtensions.cs
@@ -88,6 +88,35 @@ namespace NvGet.Extensions
 				}
 			}
 
+			// find all nodes inside a PropertyGroup node that for which the name is ending by Version
+			var propertyGroupVersionReferences = document
+				.SelectElements("PropertyGroup")
+				.SelectMany(pg => pg.SelectNodes("*").OfType<XmlElement>())
+				.Where(e => e.LocalName.EndsWith("Version", StringComparison.OrdinalIgnoreCase));
+
+			foreach(var versionProperty in propertyGroupVersionReferences)
+			{
+				var originalTrimmedName = versionProperty
+					.LocalName
+					.TrimEnd("Version");
+
+				var nameParts =
+					originalTrimmedName
+					.Select((c, i) =>
+						i > 0
+						&& char.IsUpper(c)
+						&& !char.IsUpper(originalTrimmedName[i - 1])
+						? "." + c
+						: c.ToString());
+
+				var packageName = string.Concat(nameParts).ToLowerInvariant();
+
+				if(NuGetVersion.TryParse(versionProperty.InnerText, out var nugetVersion))
+				{
+					references.Add(CreatePackageIdentity(packageName, versionProperty.InnerText));
+				}
+			}
+
 			return references
 				.Trim()
 				.ToArray();

--- a/src/NvGet/Extensions/XmlDocumentReference.cs
+++ b/src/NvGet/Extensions/XmlDocumentReference.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NvGet.Entities;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Uno.Extensions;
+
+#if WINDOWS_UWP
+using System.Text.RegularExpressions;
+using Windows.Data.Xml.Dom;
+using Windows.Storage;
+using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
+using XmlElement = Windows.Data.Xml.Dom.XmlElement;
+using XmlNode = Windows.Data.Xml.Dom.IXmlNode;
+#else
+using XmlDocument = System.Xml.XmlDocument;
+using XmlElement = System.Xml.XmlElement;
+using XmlNode = System.Xml.XmlNode;
+#endif
+
+namespace NvGet.Extensions
+{
+	public class XmlDocumentReference : DocumentReference
+	{
+		public XmlDocumentReference(XmlDocument document)
+		{
+			Document = document;
+		}
+
+		public XmlDocument Document { get; }
+
+		public override async Task Save(CancellationToken ct, string path)
+		{
+			Document.Save(ct, path);
+		}
+	}
+}

--- a/src/NvGet/Extensions/XmlDocumentReference.cs
+++ b/src/NvGet/Extensions/XmlDocumentReference.cs
@@ -34,7 +34,7 @@ namespace NvGet.Extensions
 
 		public override async Task Save(CancellationToken ct, string path)
 		{
-			Document.Save(ct, path);
+			await Document.Save(ct, path);
 		}
 	}
 }

--- a/src/NvGet/Helpers/GlobalJson.cs
+++ b/src/NvGet/Helpers/GlobalJson.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NvGet.Contracts;
+using NvGet.Entities;
+using NvGet.Extensions;
+using NuGet.Versioning;
+using Uno.Extensions;
+using Newtonsoft.Json;
+
+namespace NvGet.Helpers
+{
+	public class GlobalJson
+	{
+		[JsonProperty("msbuild-sdks")]
+		public Dictionary<string, string> MSBuildSdks { get; set; }
+	}
+}

--- a/src/NvGet/Helpers/SolutionHelper.cs
+++ b/src/NvGet/Helpers/SolutionHelper.cs
@@ -231,10 +231,4 @@ namespace NvGet.Helpers
 				.ToArray();
 		}
 	}
-
-	public class GlobalJson
-	{
-		[JsonProperty("msbuild-sdks")]
-		public Dictionary<string, string> MSBuildSdks { get; set; }
-	}
 }

--- a/src/NvGet/Helpers/SolutionHelper.cs
+++ b/src/NvGet/Helpers/SolutionHelper.cs
@@ -140,7 +140,16 @@ namespace NvGet.Helpers
 			else
 			{
 				var solutionFolder = Path.GetDirectoryName(solutionPath);
-				file = Path.Combine(solutionFolder, target.GetDescription());
+
+				if(target is FileType.DirectoryProps or FileType.DirectoryTargets or FileType.GlobalJson or FileType.CentralPackageManagement)
+				{
+					var matchingFiles = await FileHelper.GetFiles(ct, solutionFolder, nameFilter: target.GetDescription());
+					return matchingFiles.ToArray();
+				}
+				else
+				{
+					file = Path.Combine(solutionFolder, target.GetDescription());
+				}
 			}
 
 			if(file.HasValue() && await FileHelper.Exists(file))

--- a/src/NvGet/Tools/Updater/Extensions/XmlDocumentExtensions.cs
+++ b/src/NvGet/Tools/Updater/Extensions/XmlDocumentExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using Newtonsoft.Json;
+using NuGet.Versioning;
 using NvGet.Extensions;
 using NvGet.Helpers;
 using NvGet.Tools.Updater.Log;
@@ -92,6 +93,23 @@ namespace NvGet.Tools.Updater.Extensions
 					}
 
 					operations.Add(currentOperation);
+				}
+			}
+
+			var propertyGroupVersionReferences = document
+				.SelectElements("PropertyGroup")
+				.SelectMany(pg => pg.SelectNodes(packageId.Replace(".", "") + "Version").OfType<XmlElement>());
+
+			foreach(var versionProperty in propertyGroupVersionReferences)
+			{
+				if(NuGetVersion.TryParse(versionProperty.InnerText, out var previousVersion))
+				{
+					var currentOperation = operation.WithPreviousVersion(versionProperty.InnerText);
+
+					if(currentOperation.ShouldProceed())
+					{
+						versionProperty.InnerText = currentOperation.UpdatedVersion.ToString();
+					}
 				}
 			}
 

--- a/src/NvGet/Tools/Updater/NuGetUpdater.cs
+++ b/src/NvGet/Tools/Updater/NuGetUpdater.cs
@@ -144,7 +144,7 @@ namespace NvGet.Tools.Updater
 		   CancellationToken ct,
 		   UpdateOperation operation,
 		   Dictionary<FileType, string[]> targetFiles,
-		   Dictionary<string, XmlDocument> documents
+		   Dictionary<string, DocumentReference> documents
 	   )
 		{
 			var operations = new List<UpdateOperation>();
@@ -166,14 +166,19 @@ namespace NvGet.Tools.Updater
 
 					var currentOperation = operation.WithFilePath(path);
 
-					if(fileType.HasFlag(FileType.Nuspec))
+					if(fileType.HasFlag(FileType.Nuspec) && document is XmlDocumentReference xmlDocReference)
 					{
-						updates = document.UpdateDependencies(currentOperation);
+						updates = xmlDocReference.UpdateDependencies(currentOperation);
 					}
-					else if(fileType.HasAnyFlag(FileType.DirectoryProps, FileType.DirectoryTargets, FileType.Csproj, FileType.CentralPackageManagement))
+					else if(fileType.HasFlag(FileType.GlobalJson) && document is JsonDocumentReference jsonDocReference)
 					{
-						updates = document.UpdatePackageReferences(currentOperation);
-						var propertyUpdates = document.UpdateUpdateProperties(currentOperation, _parameters.UpdateProperties);
+						updates = jsonDocReference.UpdateDependencies(currentOperation);
+					}
+					else if(fileType.HasAnyFlag(FileType.DirectoryProps, FileType.DirectoryTargets, FileType.Csproj, FileType.CentralPackageManagement)
+						&& document is XmlDocumentReference xmlDocReference2)
+					{
+						updates = xmlDocReference2.Document.UpdatePackageReferences(currentOperation);
+						var propertyUpdates = xmlDocReference2.Document.UpdateUpdateProperties(currentOperation, _parameters.UpdateProperties);
 						updates = updates.Concat(propertyUpdates);
 					}
 


### PR DESCRIPTION
Adds support for updating `global.json` and `*Version` properties updates used by Uno 5.2 and later.