### PR TITLE
fix: Crash on Version and when version set to msbuild property

### DIFF
--- a/src/NvGet/Extensions/XmlDocumentExtensions.cs
+++ b/src/NvGet/Extensions/XmlDocumentExtensions.cs
@@ -92,7 +92,8 @@ namespace NvGet.Extensions
 			var propertyGroupVersionReferences = document
 				.SelectElements("PropertyGroup")
 				.SelectMany(pg => pg.SelectNodes("*").OfType<XmlElement>())
-				.Where(e => e.LocalName.EndsWith("Version", StringComparison.OrdinalIgnoreCase));
+				.Where(e => e.LocalName.EndsWith("Version", StringComparison.OrdinalIgnoreCase) &&
+				!e.LocalName.StartsWith("Version", StringComparison.OrdinalIgnoreCase));
 
 			foreach(var versionProperty in propertyGroupVersionReferences)
 			{


### PR DESCRIPTION
Fixes: #74 
Fixes: #75

## Proposed Changes
- Bug fix

## What is the current behavior?
Updater crashes when 
- csproj includes `Version` property
- PackageVersion set to build property

## What is the new behavior?
No crashes

## Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Documentation has been added/updated
- [ - ] Automated Unit / Integration tests for the changes have been added/updated
- [X] Contains **NO** breaking changes
- [N/A] Updated the Changelog
- [X] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

